### PR TITLE
Update initialize to context (- activity constraint)

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
@@ -148,7 +148,7 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
         Activity activity = (Activity) context;
         mActivityWeakReference = new WeakReference<>(activity);
 
-        UnityInitializer.getInstance().initializeUnityAds(activity, gameId,
+        UnityInitializer.getInstance().initializeUnityAds(context, gameId,
                 new IUnityAdsInitializationListener() {
             @Override
             public void onInitializationComplete() {

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
@@ -62,11 +62,6 @@ public class UnityBannerAd extends UnityMediationAdapter implements MediationBan
     private MediationBannerListener mMediationBannerListener;
 
     /**
-     * Activity needed to initialize Unity Ads.
-     */
-    private Activity activity;
-
-    /**
      * Context needed to load Unity Ads.
      */
     private Context context;
@@ -156,11 +151,10 @@ public class UnityBannerAd extends UnityMediationAdapter implements MediationBan
             }
             return;
         }
-        activity = (Activity) context;
         this.context = context;
         this.adSize = adSize;
 
-        UnityInitializer.getInstance().initializeUnityAds(activity, gameId, new IUnityAdsInitializationListener() {
+        UnityInitializer.getInstance().initializeUnityAds(context, gameId, new IUnityAdsInitializationListener() {
             @Override
             public void onInitializationComplete() {
                 Log.d(TAG, "Unity Ads successfully initialized, can now load " +

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityInitializer.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityInitializer.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.mediation.unity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.util.Log;
 
 import com.unity3d.ads.BuildConfig;
@@ -49,12 +49,12 @@ public class UnityInitializer {
     /**
      * This method will initialize {@link UnityAds}.
      *
-     * @param activity    The Activity context.
+     * @param context    The context.
      * @param gameId      Unity Ads Game ID.
      * @param initializationListener   Unity Ads Initialization listener.
      *
      */
-    public void initializeUnityAds(Activity activity, String gameId, IUnityAdsInitializationListener
+    public void initializeUnityAds(Context context, String gameId, IUnityAdsInitializationListener
             initializationListener) {
         // Check if the current device is supported by Unity Ads before initializing.
         if (!UnityAds.isSupported()) {
@@ -67,13 +67,13 @@ public class UnityInitializer {
         }
 
         // Set mediation meta data before initializing.
-        MediationMetaData mediationMetaData = new MediationMetaData(activity);
+        MediationMetaData mediationMetaData = new MediationMetaData(context);
         mediationMetaData.setName("AdMob");
         mediationMetaData.setVersion(BuildConfig.VERSION_NAME);
         mediationMetaData.set("adapter_version", UnityAds.getVersion());
         mediationMetaData.commit();
 
-        UnityAds.initialize(activity, gameId, false, true, initializationListener);
+        UnityAds.initialize(context, gameId, false, true, initializationListener);
     }
 
 }

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationAdapter.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationAdapter.java
@@ -14,7 +14,6 @@
 
 package com.google.ads.mediation.unity;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -135,7 +134,7 @@ public class UnityMediationAdapter extends Adapter {
             return;
         }
 
-        UnityInitializer.getInstance().initializeUnityAds((Activity) context, gameID,
+        UnityInitializer.getInstance().initializeUnityAds(context, gameID,
                 new IUnityAdsInitializationListener() {
             @Override
             public void onInitializationComplete() {

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
@@ -31,11 +31,6 @@ import com.unity3d.ads.mediation.IUnityAdsExtendedListener;
 public class UnityRewardedAd implements MediationRewardedAd, IUnityAdsExtendedListener {
 
     /**
-     * Mediation rewarded video ad configuration to render ad.
-     */
-    private MediationRewardedAdConfiguration mediationRewardedAdConfiguration;
-
-    /**
      * Mediation rewarded video ad listener used to forward ad load status
      * to the Google Mobile Ads SDK.
      */
@@ -115,7 +110,7 @@ public class UnityRewardedAd implements MediationRewardedAd, IUnityAdsExtendedLi
             return;
         }
 
-        UnityInitializer.getInstance().initializeUnityAds((Activity) context, gameId,
+        UnityInitializer.getInstance().initializeUnityAds(context, gameId,
                 new IUnityAdsInitializationListener() {
                     @Override
                     public void onInitializationComplete() {
@@ -134,7 +129,6 @@ public class UnityRewardedAd implements MediationRewardedAd, IUnityAdsExtendedLi
                         if (mMediationAdLoadCallback != null) {
                             mMediationAdLoadCallback.onFailure("Failed to load rewarded ad from Unity Ads.");
                         }
-                        return;
                     }
                 });
     }


### PR DESCRIPTION
**Description**
Previously the adapters were calling UnityAds.intialize with an activity. This method is now deprecated as the 3.5 SDK allows initialize to be called with a context. 

**How**
-Updated the function call
-Deleted local activity variables where applicable

**Test**
Ads are still loading/showing successfully.