### PR TITLE
Fix build error by using AdRequest.

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdsAdapterUtils.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdsAdapterUtils.java
@@ -1,0 +1,123 @@
+
+package com.google.ads.mediation.unity;
+
+import androidx.annotation.NonNull;
+
+import com.google.ads.mediation.unity.UnityMediationAdapter.AdapterError;
+import com.unity3d.ads.UnityAds.UnityAdsError;
+import com.unity3d.services.banners.BannerErrorInfo;
+
+/**
+ * Utility class for the Unity adapter.
+ */
+public class UnityAdsAdapterUtils {
+
+    /**
+     * Private constructor
+     */
+    private UnityAdsAdapterUtils() {
+    }
+
+    /**
+     * Creates a formatted SDK error message based on the specified {@link BannerErrorInfo}.
+     *
+     * @param errorInfo error object from Unity.
+     * @return the error message.
+     */
+    @NonNull
+    static String createSDKError(@NonNull BannerErrorInfo errorInfo) {
+        return String.format("%d: %s", getMediationErrorCode(errorInfo), errorInfo.errorMessage);
+    }
+
+    /**
+     * Creates a formatted SDK error message based on the specified {@link UnityAdsError}.
+     *
+     * @param unityAdsError error object from Unity.
+     * @param description   the error message.
+     * @return the error message.
+     */
+    @NonNull
+    static String createSDKError(@NonNull UnityAdsError unityAdsError, @NonNull String description) {
+        return String.format("%d: %s", getMediationErrorCode(unityAdsError), description);
+    }
+
+    /**
+     * Creates a formatted adapter error string given a code and description.
+     *
+     * @param code        the error code.
+     * @param description the error message.
+     * @return the error message.
+     */
+    @NonNull
+    static String createAdapterError(@AdapterError int code, String description) {
+        return String.format("%d: %s", code, description);
+    }
+
+    /**
+     * Gets the mediation specific error code for the specified {@link BannerErrorInfo}.
+     *
+     * @param errorInfo error object from Unity.
+     * @return mediation specific error code.
+     */
+    static int getMediationErrorCode(@NonNull BannerErrorInfo errorInfo) {
+        int errorCode = 200;
+        switch (errorInfo.errorCode) {
+            case UNKNOWN:
+                errorCode = 201;
+                break;
+            case NATIVE_ERROR:
+                errorCode = 202;
+                break;
+            case WEBVIEW_ERROR:
+                errorCode = 203;
+                break;
+            case NO_FILL:
+                errorCode = 204;
+                break;
+        }
+        return errorCode;
+    }
+
+    /**
+     * Gets the mediation specific error code for the specified {@link UnityAdsError}.
+     *
+     * @param unityAdsError error object from Unity.
+     * @return mediation specific error code.
+     */
+    static int getMediationErrorCode(@NonNull UnityAdsError unityAdsError) {
+        int errorCode = 0;
+        switch (unityAdsError) {
+            case NOT_INITIALIZED:
+                errorCode = 1;
+                break;
+            case INITIALIZE_FAILED:
+                errorCode = 2;
+                break;
+            case INVALID_ARGUMENT:
+                errorCode = 3;
+                break;
+            case VIDEO_PLAYER_ERROR:
+                errorCode = 4;
+                break;
+            case INIT_SANITY_CHECK_FAIL:
+                errorCode = 5;
+                break;
+            case AD_BLOCKER_DETECTED:
+                errorCode = 6;
+                break;
+            case FILE_IO_ERROR:
+                errorCode = 7;
+                break;
+            case DEVICE_ID_ERROR:
+                errorCode = 8;
+                break;
+            case SHOW_ERROR:
+                errorCode = 9;
+                break;
+            case INTERNAL_ERROR:
+                errorCode = 10;
+                break;
+        }
+        return errorCode;
+    }
+}

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationAdapter.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationAdapter.java
@@ -19,6 +19,8 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.IntDef;
+
 import com.google.android.gms.ads.mediation.Adapter;
 import com.google.android.gms.ads.mediation.InitializationCompleteCallback;
 import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
@@ -31,6 +33,8 @@ import com.unity3d.ads.BuildConfig;
 import com.unity3d.ads.IUnityAdsInitializationListener;
 import com.unity3d.ads.UnityAds;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.HashSet;
 import java.util.List;
 
@@ -44,6 +48,49 @@ public class UnityMediationAdapter extends Adapter {
    * TAG used for logging messages.
    */
   static final String TAG = UnityMediationAdapter.class.getSimpleName();
+
+  // region Error Codes
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef(
+          value = {
+                  ERROR_INVALID_SERVER_PARAMETERS,
+                  ERROR_PLACEMENT_STATE_NO_FILL,
+                  ERROR_PLACEMENT_STATE_DISABLED,
+                  ERROR_NULL_CONTEXT,
+                  ERROR_CONTEXT_NOT_ACTIVITY,
+                  ERROR_AD_NOT_READY,
+                  ERROR_UNITY_ADS_NOT_SUPPORTED,
+                  ERROR_AD_ALREADY_LOADING,
+                  ERROR_FINISH
+          })
+  @interface AdapterError {}
+
+  /** Invalid server parameters. */
+  static final int ERROR_INVALID_SERVER_PARAMETERS = 101;
+
+  /** UnityAds returned a placement with a {@link PlacementStateNO_FILL} state. */
+  static final int ERROR_PLACEMENT_STATE_NO_FILL = 102;
+
+  /** UnityAds returned a placement with a {@link PlacementState#DISABLED} state. */
+  static final int ERROR_PLACEMENT_STATE_DISABLED = 103;
+
+  /** Tried to show an ad with a {@code null} context. */
+  static final int ERROR_NULL_CONTEXT = 104;
+
+  static final int ERROR_CONTEXT_NOT_ACTIVITY = 105;
+
+  /** Tried to show an ad that's not ready to be shown. */
+  static final int ERROR_AD_NOT_READY = 106;
+
+  /** UnityAds is not supported on the device. */
+  static final int ERROR_UNITY_ADS_NOT_SUPPORTED = 107;
+
+  /** UnityAds can only load 1 ad per placement at a time. */
+  static final int ERROR_AD_ALREADY_LOADING = 108;
+
+  /** UnityAds finished with a {@link FinishState#ERROR} state. */
+  static final int ERROR_FINISH = 109;
+  // endregion
 
   /**
    * Key to obtain Game ID, required for loading Unity Ads.


### PR DESCRIPTION
Fix the build error introduced by calling a not-accessible class AdRequest for Error Code.

Admob categorized error codes into two: AdapterError and SDKError. We map UnityAds's errors accordingly.
3.5.0 adapter change removed this logic and used the error code from a not accessible class AdRequest. As a result, the build failed.
