### PR TITLE
Removing calls to UnityAds.isReady()

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
@@ -58,6 +58,11 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
   private String mPlacementId;
 
   /**
+   * Placement ID kept once placement was properly loaded internally.
+   */
+  private String mLoadedPlacementId;
+
+  /**
    * An Android {@link Activity} weak reference used to show ads.
    */
   private WeakReference<Activity> mActivityWeakReference;
@@ -80,6 +85,7 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
     public void onUnityAdsAdLoaded(String placementId) {
       Log.d(TAG, "Unity Ads interstitial ad successfully loaded for placement ID '"
           + placementId + "'.");
+      mLoadedPlacementId = placementId;
       if (mMediationInterstitialListener != null) {
         mMediationInterstitialListener.onAdLoaded(UnityAdapter.this);
       }
@@ -212,7 +218,7 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
       return;
     }
 
-    if (!UnityAds.isReady(mPlacementId)) {
+    if (mLoadedPlacementId == null) {
       Log.w(TAG,
           "Unity Ads failed to show interstitial ad for placement ID '" + mPlacementId +
               "'. Placement is not ready.");
@@ -263,6 +269,9 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
       // Unity Ads ad failed to show.
       String sdkError = createSDKShowError(error, message);
       Log.w(TAG, "Unity Ads returned an error: " + sdkError);
+      if (mMediationInterstitialListener != null && error == UnityAdsShowError.NOT_READY) {
+        mMediationInterstitialListener.onAdClosed(UnityAdapter.this);
+      }
     }
   };
 

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
@@ -63,6 +63,11 @@ public class UnityRewardedAd implements MediationRewardedAd {
   private String mPlacementId;
 
   /**
+   * Placement ID kept once placement was properly loaded internally.
+   */
+  private String mLoadedPlacementId;
+
+  /**
    * A list of placement IDs that are currently loaded to prevent duplicate requests.
    */
   private static HashMap<String, WeakReference<UnityRewardedAd>> mPlacementsInUse = new HashMap<>();
@@ -75,6 +80,7 @@ public class UnityRewardedAd implements MediationRewardedAd {
     public void onUnityAdsAdLoaded(String placementId) {
       Log.d(TAG, "Unity Ads rewarded ad successfully loaded for placement ID '"
           + placementId + "'");
+      mLoadedPlacementId = placementId;
       if (mMediationAdLoadCallback == null) {
         return;
       }
@@ -182,7 +188,7 @@ public class UnityRewardedAd implements MediationRewardedAd {
     Activity activity = (Activity) context;
 
     // Check if the placement is ready before showing
-    if (!UnityAds.isReady(mPlacementId)) {
+    if (mLoadedPlacementId == null) {
       String adapterError = createAdapterError(ERROR_AD_NOT_READY, "Ad is not ready to be shown.");
       Log.w(TAG, "Failed to show Unity Ads Rewarded ad: " + adapterError);
       if (mMediationRewardedAdCallback != null) {


### PR DESCRIPTION
The goal of this PR is to match what was decided in the design document: https://docs.google.com/document/d/1fdNXquNCUeaI8U5nLMcCpVQOtVuhWTfjBPaXGPBpmns/edit#heading=h.txbn3yfvyvzr

We need to remove any calls to UnityAds.isReady as it would remove our ability to see the impact of Ad invalidation when a client app tries to show an Ad that was previously invalidated after being loaded.