### PR TITLE
<chore>(UADSDK-2289):<Android>: Add objectId for Load/Show API calls in Waterfall.

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdapter.java
@@ -41,7 +41,11 @@ import com.unity3d.ads.IUnityAdsShowListener;
 import com.unity3d.ads.UnityAds;
 import com.unity3d.ads.UnityAds.UnityAdsLoadError;
 import com.unity3d.ads.UnityAds.UnityAdsShowError;
+import com.unity3d.ads.UnityAdsLoadOptions;
+import com.unity3d.ads.UnityAdsShowOptions;
+
 import java.lang.ref.WeakReference;
+import java.util.UUID;
 
 /**
  * The {@link UnityAdapter} is used to load Unity ads and mediate the callbacks between Google
@@ -60,6 +64,11 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
    * Placement ID used to determine what type of ad to load.
    */
   private String placementId;
+
+  /**
+   * Object ID used to track loaded/shown ads.
+   */
+  private String objectId;
 
   /**
    * An Android {@link Activity} weak reference used to show ads.
@@ -124,7 +133,7 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
     this.mediationInterstitialListener = mediationInterstitialListener;
     eventAdapter = new UnityInterstitialEventAdapter(this.mediationInterstitialListener, this);
 
-    String gameId = serverParameters.getString(KEY_GAME_ID);
+    final String gameId = serverParameters.getString(KEY_GAME_ID);
     placementId = serverParameters.getString(KEY_PLACEMENT_ID);
     if (!areValidIds(gameId, placementId)) {
       sendAdFailedToLoad(ERROR_INVALID_SERVER_PARAMETERS, "Missing or invalid server parameters.");
@@ -163,8 +172,10 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
             }
           }
         });
-
-    UnityAds.load(placementId, unityLoadListener);
+    objectId = UUID.randomUUID().toString();
+    UnityAdsLoadOptions unityAdsLoadOptions = new UnityAdsLoadOptions();
+    unityAdsLoadOptions.setObjectId(objectId);
+    UnityAds.load(placementId, unityAdsLoadOptions, unityLoadListener);
   }
 
   private void sendAdFailedToLoad(int errorCode, String errorDescription) {
@@ -192,8 +203,10 @@ public class UnityAdapter extends UnityMediationAdapter implements MediationInte
       Log.w(TAG, "Unity Ads received call to show before successfully loading an ad.");
     }
 
+    UnityAdsShowOptions unityAdsShowOptions = new UnityAdsShowOptions();
+    unityAdsShowOptions.setObjectId(objectId);
     // UnityAds can handle a null placement ID so show is always called here.
-    UnityAds.show(activityReference, placementId, unityShowListener);
+    UnityAds.show(activityReference, placementId, unityAdsShowOptions, unityShowListener);
   }
 
   /**

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
@@ -144,9 +144,9 @@ public class UnityBannerAd extends UnityMediationAdapter implements MediationBan
           "Unity Ads requires an Activity context to load ads.");
       return;
     }
-    Activity activity = (Activity) context;
+    final Activity activity = (Activity) context;
 
-    UnityBannerSize unityBannerSize = UnityAdsAdapterUtils.getUnityBannerSize(context, adSize);
+    final UnityBannerSize unityBannerSize = UnityAdsAdapterUtils.getUnityBannerSize(context, adSize);
     if (unityBannerSize == null) {
       String errorMessage = String
           .format("There is no matching Unity Ads ad size for Google ad size: %s",

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
@@ -38,6 +38,10 @@ import com.unity3d.ads.IUnityAdsShowListener;
 import com.unity3d.ads.UnityAds;
 import com.unity3d.ads.UnityAds.UnityAdsLoadError;
 import com.unity3d.ads.UnityAds.UnityAdsShowError;
+import com.unity3d.ads.UnityAdsLoadOptions;
+import com.unity3d.ads.UnityAdsShowOptions;
+
+import java.util.UUID;
 
 public class UnityRewardedAd implements MediationRewardedAd {
 
@@ -58,6 +62,11 @@ public class UnityRewardedAd implements MediationRewardedAd {
    * Placement ID used to determine what type of ad to load.
    */
   private String placementId;
+
+  /**
+   * Object ID used to track loaded/shown ads.
+   */
+  private String objectId;
 
   /**
    * UnityRewardedEventAdapter instance to send events from the mediationRewardedAdCallback.
@@ -101,8 +110,8 @@ public class UnityRewardedAd implements MediationRewardedAd {
     }
 
     Bundle serverParameters = mediationRewardedAdConfiguration.getServerParameters();
-    String gameId = serverParameters.getString(UnityMediationAdapter.KEY_GAME_ID);
-    String placementId = serverParameters.getString(UnityMediationAdapter.KEY_PLACEMENT_ID);
+    final String gameId = serverParameters.getString(UnityMediationAdapter.KEY_GAME_ID);
+    final String placementId = serverParameters.getString(UnityMediationAdapter.KEY_PLACEMENT_ID);
     if (!UnityAdapter.areValidIds(gameId, placementId)) {
       sendRewardedLoadFailure(
           createAdError(ERROR_INVALID_SERVER_PARAMETERS, "Missing or invalid server parameters."));
@@ -130,7 +139,11 @@ public class UnityRewardedAd implements MediationRewardedAd {
           }
         });
 
-    UnityAds.load(placementId, unityLoadListener);
+    objectId = UUID.randomUUID().toString();
+    UnityAdsLoadOptions unityAdsLoadOptions = new UnityAdsLoadOptions();
+    unityAdsLoadOptions.setObjectId(objectId);
+
+    UnityAds.load(placementId, unityAdsLoadOptions, unityLoadListener);
   }
 
   @Override
@@ -151,8 +164,11 @@ public class UnityRewardedAd implements MediationRewardedAd {
       Log.w(TAG, "Unity Ads received call to show before successfully loading an ad.");
     }
 
+    UnityAdsShowOptions unityAdsShowOptions = new UnityAdsShowOptions();
+    unityAdsShowOptions.setObjectId(objectId);
+
     // UnityAds can handle a null placement ID so show is always called here.
-    UnityAds.show(activity, placementId, unityShowListener);
+    UnityAds.show(activity, placementId, unityAdsShowOptions, unityShowListener);
   }
 
   /**


### PR DESCRIPTION
To improve fill expectation issues, enhance tracking and provide sequential caching, we must add Object ID to load and show request of an Ad Unit.

This PR is to add a UUID when issuing Load request and use the same (as object ID) when doing the Show call later.

Manually tested in Waterfall that we send Load and Show options as expected in the adapter.