### PR TITLE
[Internal Review] Add usage of onBannerShown callback to report impression event

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityBannerAd.java
@@ -85,6 +85,14 @@ public class UnityBannerAd extends UnityMediationAdapter implements MediationBan
     }
 
     @Override
+    public void onBannerShown(BannerView bannerView) {
+      String logMessage = String.format("Unity Ads showing banner ad for placement ID: %s",
+              UnityBannerAd.this.bannerView.getPlacementId());
+      Log.d(TAG, logMessage);
+      eventAdapter.sendAdEvent(AdEvent.IMPRESSION);
+    }
+
+    @Override
     public void onBannerClick(BannerView bannerView) {
       String logMessage = String.format("Unity Ads banner ad was clicked for placement ID: %s",
           UnityBannerAd.this.bannerView.getPlacementId());

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationBannerAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityMediationBannerAd.java
@@ -97,8 +97,21 @@ public class UnityMediationBannerAd implements MediationBannerAd, BannerView.ILi
             bannerView.getPlacementId());
     Log.d(UnityMediationAdapter.TAG, logMessage);
     mediationBannerAdCallback = mediationBannerAdLoadCallback.onSuccess(this);
-    // TODO(b/276467762): Find a place to call mediatinoBannerAdCallback.reportAdImpression(), if
-    // any.
+  }
+
+  @Override
+  public void onBannerShown(BannerView bannerView) {
+    String logMessage =
+            String.format(
+                    "Unity Ads showing banner ad for placement ID: %s",
+                    bannerView.getPlacementId());
+    Log.d(UnityMediationAdapter.TAG, logMessage);
+
+    if (mediationBannerAdCallback == null) {
+      return;
+    }
+
+    mediationBannerAdCallback.reportAdImpression();
   }
 
   @Override


### PR DESCRIPTION
In this PR I added the use of onBannerShown in the banner listeners in UnityBannerAd and UnityMediationBannerAd. Inside of the onBannerShown callback I reported the impression event following the style of the other callbacks in the class. I imported our 4.8.0 RC into my project for testing. 