### PR TITLE
Add required watermark PNG to pass down to Unity Ads SDK in ShowOptions.

### DIFF
--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdsLoader.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityAdsLoader.java
@@ -1,6 +1,8 @@
 package com.google.ads.mediation.unity;
 
 import android.app.Activity;
+
+import com.google.android.gms.ads.mediation.MediationAdConfiguration;
 import com.unity3d.ads.IUnityAdsLoadListener;
 import com.unity3d.ads.IUnityAdsShowListener;
 import com.unity3d.ads.UnityAds;
@@ -9,6 +11,8 @@ import com.unity3d.ads.UnityAdsShowOptions;
 
 /** Wrapper class for {@link UnitAds#load} and {@link UnityAds#show} */
 class UnityAdsLoader {
+  private static final String WATERMARK_KEY = "watermark";
+
   public void load(
       String placementId,
       UnityAdsLoadOptions unityAdsLoadOptions,
@@ -30,9 +34,10 @@ class UnityAdsLoader {
     return unityAdsLoadOptions;
   }
 
-  public UnityAdsShowOptions createUnityAdsShowOptionsWithId(String objectId) {
+  public UnityAdsShowOptions createUnityAdsShowOptionsWithId(String objectId, MediationAdConfiguration adConfiguration) {
     UnityAdsShowOptions unityAdsShowOptions = new UnityAdsShowOptions();
     unityAdsShowOptions.setObjectId(objectId);
+    unityAdsShowOptions.set(WATERMARK_KEY, adConfiguration.getWatermark());
     return unityAdsShowOptions;
   }
 }

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityInterstitialAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityInterstitialAd.java
@@ -238,7 +238,7 @@ public class UnityInterstitialAd
     }
 
     UnityAdsShowOptions unityAdsShowOptions =
-        unityAdsLoader.createUnityAdsShowOptionsWithId(objectId);
+        unityAdsLoader.createUnityAdsShowOptionsWithId(objectId, adConfiguration);
     // UnityAds can handle a null placement ID so show is always called here.
     unityAdsLoader.show(activityReference, placementId, unityAdsShowOptions, this);
   }

--- a/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
+++ b/ThirdPartyAdapters/unity/unity/src/main/java/com/google/ads/mediation/unity/UnityRewardedAd.java
@@ -26,9 +26,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
 import com.google.android.gms.ads.mediation.MediationRewardedAd;
@@ -42,6 +44,7 @@ import com.unity3d.ads.UnityAds.UnityAdsLoadError;
 import com.unity3d.ads.UnityAds.UnityAdsShowError;
 import com.unity3d.ads.UnityAdsLoadOptions;
 import com.unity3d.ads.UnityAdsShowOptions;
+
 import java.util.UUID;
 
 /**
@@ -162,7 +165,7 @@ public class UnityRewardedAd implements MediationRewardedAd {
     }
 
     UnityAdsShowOptions unityAdsShowOptions =
-        unityAdsLoader.createUnityAdsShowOptionsWithId(objectId);
+        unityAdsLoader.createUnityAdsShowOptionsWithId(objectId, mediationRewardedAdConfiguration);
 
     // UnityAds can handle a null placement ID so show is always called here.
     unityAdsLoader.show(activity, placementId, unityAdsShowOptions, unityShowListener);


### PR DESCRIPTION
- Adds in `watermark` including Base64 encoded PNG which must be used during ad rendering.
- Use ShowOptions dictionary to pass down the PNG during rendering